### PR TITLE
This is the time format used in credentials now

### DIFF
--- a/bin/assume-role-exec
+++ b/bin/assume-role-exec
@@ -64,7 +64,7 @@ then
   fi
 
   log "Found credentials in $credpath"
-  expiration="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(jq -r .Credentials.Expiration $credpath)" +%s)"
+  expiration="$(date -u -j -f '%Y-%m-%dT%H:%M:%S+00:00' "$(jq -r .Credentials.Expiration $credpath)" +%s)"
   current="$(date +%s)"
   delta=$((expiration - current))
   if [[ $delta < 0 ]]


### PR DESCRIPTION
Maybe we'd be better of leaving off the TZ entirely if possible? I didn't try. But this got cached credentials working again.