### PR TITLE
kubectl-formatter, pod-to-node report, and k8s shell improvements

### DIFF
--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -14,6 +14,7 @@
 #
 # Format types:
 #   @qty   Kubernetes quantity normalization (e.g., 10m -> 0.010)
+#   @ts    Relative timestamp (e.g., "2026-03-03T01:15:05Z" -> "5m", "1h15m")
 
 set -euo pipefail
 
@@ -21,7 +22,9 @@ if [[ $# -eq 0 ]]; then
   echo "Usage: $0 field_spec [field_spec ...]" >&2
   echo "" >&2
   echo "Field spec: [HEADER:]field_path[@format_type]" >&2
-  echo "Format types: @qty (Kubernetes quantity, e.g. 10m -> 0.010)" >&2
+  echo "Format types:" >&2
+  echo "  @qty  Kubernetes quantity (e.g. 10m -> 0.010)" >&2
+  echo "  @ts   Relative timestamp (e.g. 2026-03-03T01:15:05Z -> 5m)" >&2
   exit 1
 fi
 
@@ -39,6 +42,38 @@ def normalize_qty:
     .
   else
     .
+  end;
+def relative_ts:
+  # Parse ISO 8601 timestamp and format as kubectl-style relative age.
+  # Handles: "2026-03-03T01:15:05Z" -> "5m" or "1h15m" or "3d" etc.
+  if . == "" then "<none>"
+  else
+    (now | floor) as $now |
+    # Try with fractional seconds first, fall back to without
+    (if test("\\.[0-9]+Z$") then
+       gsub("\\.[0-9]+Z$"; "Z")
+     else . end
+     | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $ts |
+    ([$now - $ts, 0] | max) as $diff |
+    ($diff / 86400 | floor) as $days |
+    ($diff % 86400 / 3600 | floor) as $hours |
+    ($diff % 3600 / 60 | floor) as $mins |
+    ($diff % 60 | floor) as $secs |
+    if $days >= 365 then
+      (($days / 365 | floor) | tostring) + "y" +
+      if ($days % 365) >= 1 then (($days % 365 | floor) | tostring) + "d" else "" end
+    elif $days >= 1 then
+      ($days | tostring) + "d" +
+      if $hours >= 1 then ($hours | tostring) + "h" else "" end
+    elif $hours >= 1 then
+      ($hours | tostring) + "h" +
+      if $mins >= 1 then ($mins | tostring) + "m" else "" end
+    elif $mins >= 1 then
+      ($mins | tostring) + "m" +
+      if $secs >= 1 then ($secs | tostring) + "s" else "" end
+    else
+      ($secs | tostring) + "s"
+    end
   end;
 def getpath_str(p):
   reduce (p | split(".")[]) as $key
@@ -86,6 +121,7 @@ for spec in "$@"; do
   accessor="(getpath_str(\"${field_path}\") // \"\" | tostring"
   case "$fmt" in
     qty)  jq_fields+="${accessor} | normalize_qty)," ;;
+    ts)   jq_fields+="${accessor} | relative_ts)," ;;
     "")   jq_fields+="${accessor})," ;;
     *)    echo "Unknown format type: @${fmt}" >&2; exit 1 ;;
   esac

--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -30,6 +30,7 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
+# shellcheck disable=SC2016
 jq_helpers='
 def normalize_qty:
   if test("^[0-9]+m$") then
@@ -123,28 +124,28 @@ jq_fields=""
 for spec in "$@"; do
   # Parse optional HEADER: prefix
   custom_header=""
-  rest="$spec"
-  if [[ "$rest" == *:* ]]; then
+  rest="${spec}"
+  if [[ "${rest}" == *:* ]]; then
     # Only treat as custom header if the part before : has no dots
     # (to avoid confusing "metadata.labels:app" with a header prefix)
     maybe_header="${rest%%:*}"
-    if [[ "$maybe_header" != *.* ]]; then
-      custom_header="$maybe_header"
+    if [[ "${maybe_header}" != *.* ]]; then
+      custom_header="${maybe_header}"
       rest="${rest#*:}"
     fi
   fi
 
   # Parse optional @format suffix
   fmt=""
-  if [[ "$rest" == *@* ]]; then
+  if [[ "${rest}" == *@* ]]; then
     fmt="${rest##*@}"
     rest="${rest%@*}"
   fi
 
-  field_path="$rest"
+  field_path="${rest}"
 
   # Build header
-  if [[ -n "$custom_header" ]]; then
+  if [[ -n "${custom_header}" ]]; then
     h="${custom_header//_/-}"
     h="${h^^}"
   else
@@ -155,7 +156,7 @@ for spec in "$@"; do
 
   # Build jq accessor with optional format
   accessor="(getpath_str(\"${field_path}\") // \"\" | tostring"
-  case "$fmt" in
+  case "${fmt}" in
     qty)  jq_fields+="${accessor} | normalize_qty)," ;;
     ts)   jq_fields+="${accessor} | relative_ts)," ;;
     mem)  jq_fields+="${accessor} | normalize_mem)," ;;

--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -33,15 +33,20 @@ def normalize_cpu:
   else
     .
   end;
+def getpath_str(p):
+  reduce (p | split(".")[]) as $key
+    (.; if $key | test("^[0-9]+$") then .[$key | tonumber] // null
+        else .[$key] // null end);
 '
 
 # Build the jq expression to extract each row
 jq_fields=""
 for f in "${fields[@]}"; do
+  accessor="(getpath_str(\"${f}\") // \"\" | tostring"
   if [[ "$f" == *cpu* ]]; then
-    jq_fields+="(.\"${f}\" // \"\" | tostring | normalize_cpu),"
+    jq_fields+="${accessor} | normalize_cpu),"
   else
-    jq_fields+="(.\"${f}\" // \"\" | tostring),"
+    jq_fields+="${accessor}),"
   fi
 done
 # Remove trailing comma

--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Format JSON with a top-level "items" array into a kubectl-like table.
+# Usage: cat data.json | formatter.sh field1 field2 ...
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 field1 [field2 ...]" >&2
+  exit 1
+fi
+
+fields=("$@")
+
+# Build jq filter that extracts fields and normalizes CPU values.
+# CPU fields (containing "cpu") have millicpu notation converted:
+#   "10m"  -> "0.010"
+#   "500m" -> "0.500"
+#   "24"   -> "24"
+jq_normalize='
+def normalize_cpu:
+  if test("^[0-9]+m$") then
+    (ltrimstr("") | rtrimstr("m") | tonumber / 1000)
+    | tostring
+    | if test("\\.") then
+        # pad to 3 decimal places
+        split(".") | .[0] + "." + (.[1] + "000")[0:3]
+      else
+        . + ".000"
+      end
+  elif test("^[0-9]+(\\.[0-9]+)?$") then
+    .
+  else
+    .
+  end;
+'
+
+# Build the jq expression to extract each row
+jq_fields=""
+for f in "${fields[@]}"; do
+  if [[ "$f" == *cpu* ]]; then
+    jq_fields+="(.\"${f}\" // \"\" | tostring | normalize_cpu),"
+  else
+    jq_fields+="(.\"${f}\" // \"\" | tostring),"
+  fi
+done
+# Remove trailing comma
+jq_fields="${jq_fields%,}"
+
+# Build header: uppercase, underscores to hyphens
+header=""
+for f in "${fields[@]}"; do
+  h="${f//_/-}"
+  h="${h^^}"
+  header+="${h}\t"
+done
+
+# Run jq and format with column -t
+{
+  printf '%b\n' "${header%\\t}"
+  jq -r "${jq_normalize} .items[] | [${jq_fields}] | @tsv"
+} | column -t

--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
 #
 # Format JSON with a top-level "items" array into a kubectl-like table.
-# Usage: cat data.json | formatter.sh field1 field2 ...
+#
+# Usage: cat data.json | kubectl-formatter field_spec [field_spec ...]
+#
+# Field spec format: [HEADER:]field_path[@format_type]
+#
+# Examples:
+#   namespace                     -> header: NAMESPACE,    field: namespace
+#   IMAGE:spec.containers.0.image -> header: IMAGE,        field: spec.containers.0.image
+#   cpu_request@qty               -> header: CPU-REQUEST,  field: cpu_request, format: qty
+#   CPU:spec.cpu@qty              -> header: CPU,          field: spec.cpu,    format: qty
+#
+# Format types:
+#   @qty   Kubernetes quantity normalization (e.g., 10m -> 0.010)
 
 set -euo pipefail
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $0 field1 [field2 ...]" >&2
+  echo "Usage: $0 field_spec [field_spec ...]" >&2
+  echo "" >&2
+  echo "Field spec: [HEADER:]field_path[@format_type]" >&2
+  echo "Format types: @qty (Kubernetes quantity, e.g. 10m -> 0.010)" >&2
   exit 1
 fi
 
-fields=("$@")
-
-# Build jq filter that extracts fields and normalizes CPU values.
-# CPU fields (containing "cpu") have millicpu notation converted:
-#   "10m"  -> "0.010"
-#   "500m" -> "0.500"
-#   "24"   -> "24"
-jq_normalize='
-def normalize_cpu:
+jq_helpers='
+def normalize_qty:
   if test("^[0-9]+m$") then
-    (ltrimstr("") | rtrimstr("m") | tonumber / 1000)
+    (rtrimstr("m") | tonumber / 1000)
     | tostring
     | if test("\\.") then
-        # pad to 3 decimal places
         split(".") | .[0] + "." + (.[1] + "000")[0:3]
       else
         . + ".000"
@@ -39,29 +46,56 @@ def getpath_str(p):
         else .[$key] // null end);
 '
 
-# Build the jq expression to extract each row
+header=""
 jq_fields=""
-for f in "${fields[@]}"; do
-  accessor="(getpath_str(\"${f}\") // \"\" | tostring"
-  if [[ "$f" == *cpu* ]]; then
-    jq_fields+="${accessor} | normalize_cpu),"
-  else
-    jq_fields+="${accessor}),"
+
+for spec in "$@"; do
+  # Parse optional HEADER: prefix
+  custom_header=""
+  rest="$spec"
+  if [[ "$rest" == *:* ]]; then
+    # Only treat as custom header if the part before : has no dots
+    # (to avoid confusing "metadata.labels:app" with a header prefix)
+    maybe_header="${rest%%:*}"
+    if [[ "$maybe_header" != *.* ]]; then
+      custom_header="$maybe_header"
+      rest="${rest#*:}"
+    fi
   fi
+
+  # Parse optional @format suffix
+  fmt=""
+  if [[ "$rest" == *@* ]]; then
+    fmt="${rest##*@}"
+    rest="${rest%@*}"
+  fi
+
+  field_path="$rest"
+
+  # Build header
+  if [[ -n "$custom_header" ]]; then
+    h="${custom_header//_/-}"
+    h="${h^^}"
+  else
+    h="${field_path//_/-}"
+    h="${h^^}"
+  fi
+  header+="${h}\t"
+
+  # Build jq accessor with optional format
+  accessor="(getpath_str(\"${field_path}\") // \"\" | tostring"
+  case "$fmt" in
+    qty)  jq_fields+="${accessor} | normalize_qty)," ;;
+    "")   jq_fields+="${accessor})," ;;
+    *)    echo "Unknown format type: @${fmt}" >&2; exit 1 ;;
+  esac
 done
+
 # Remove trailing comma
 jq_fields="${jq_fields%,}"
-
-# Build header: uppercase, underscores to hyphens
-header=""
-for f in "${fields[@]}"; do
-  h="${f//_/-}"
-  h="${h^^}"
-  header+="${h}\t"
-done
 
 # Run jq and format with column -t
 {
   printf '%b\n' "${header%\\t}"
-  jq -r "${jq_normalize} .items[] | [${jq_fields}] | @tsv"
+  jq -r "${jq_helpers} .items[] | [${jq_fields}] | @tsv"
 } | column -t

--- a/bin/kubectl-formatter
+++ b/bin/kubectl-formatter
@@ -15,6 +15,7 @@
 # Format types:
 #   @qty   Kubernetes quantity normalization (e.g., 10m -> 0.010)
 #   @ts    Relative timestamp (e.g., "2026-03-03T01:15:05Z" -> "5m", "1h15m")
+#   @mem   Memory quantity normalization (e.g., "1974266625" -> "1.8Gi", "32272432Ki" -> "30.8Gi")
 
 set -euo pipefail
 
@@ -25,6 +26,7 @@ if [[ $# -eq 0 ]]; then
   echo "Format types:" >&2
   echo "  @qty  Kubernetes quantity (e.g. 10m -> 0.010)" >&2
   echo "  @ts   Relative timestamp (e.g. 2026-03-03T01:15:05Z -> 5m)" >&2
+  echo "  @mem  Memory quantity (e.g. 1974266625 -> 1.8Gi)" >&2
   exit 1
 fi
 
@@ -43,6 +45,40 @@ def normalize_qty:
   else
     .
   end;
+def normalize_mem:
+  # Normalize Kubernetes memory quantities to a human-readable form.
+  # Input formats: raw bytes, Ki, Mi, Gi, Ti, Ei (binary) or k, M, G, T, E (decimal).
+  # Output: best-fit binary unit (Ki, Mi, Gi, Ti).
+  def to_bytes:
+    if test("^[0-9]+Ei$") then rtrimstr("Ei") | tonumber * 1152921504606846976
+    elif test("^[0-9]+Pi$") then rtrimstr("Pi") | tonumber * 1125899906842624
+    elif test("^[0-9]+Ti$") then rtrimstr("Ti") | tonumber * 1099511627776
+    elif test("^[0-9]+Gi$") then rtrimstr("Gi") | tonumber * 1073741824
+    elif test("^[0-9]+Mi$") then rtrimstr("Mi") | tonumber * 1048576
+    elif test("^[0-9]+Ki$") then rtrimstr("Ki") | tonumber * 1024
+    elif test("^[0-9]+E$") then rtrimstr("E") | tonumber * 1000000000000000000
+    elif test("^[0-9]+P$") then rtrimstr("P") | tonumber * 1000000000000000
+    elif test("^[0-9]+T$") then rtrimstr("T") | tonumber * 1000000000000
+    elif test("^[0-9]+G$") then rtrimstr("G") | tonumber * 1000000000
+    elif test("^[0-9]+M$") then rtrimstr("M") | tonumber * 1000000
+    elif test("^[0-9]+k$") then rtrimstr("k") | tonumber * 1000
+    elif test("^[0-9]+$") then tonumber
+    else null end;
+  def fmt_bytes(bytes):
+    if bytes >= 1099511627776 then
+      ((bytes / 1099511627776 * 10 | floor) / 10 | tostring) + "Ti"
+    elif bytes >= 1073741824 then
+      ((bytes / 1073741824 * 10 | floor) / 10 | tostring) + "Gi"
+    elif bytes >= 1048576 then
+      ((bytes / 1048576 * 10 | floor) / 10 | tostring) + "Mi"
+    elif bytes >= 1024 then
+      ((bytes / 1024 * 10 | floor) / 10 | tostring) + "Ki"
+    else
+      (bytes | tostring) + "B"
+    end;
+  to_bytes as $b |
+  if $b == null then .
+  else fmt_bytes($b) end;
 def relative_ts:
   # Parse ISO 8601 timestamp and format as kubectl-style relative age.
   # Handles: "2026-03-03T01:15:05Z" -> "5m" or "1h15m" or "3d" etc.
@@ -122,6 +158,7 @@ for spec in "$@"; do
   case "$fmt" in
     qty)  jq_fields+="${accessor} | normalize_qty)," ;;
     ts)   jq_fields+="${accessor} | relative_ts)," ;;
+    mem)  jq_fields+="${accessor} | normalize_mem)," ;;
     "")   jq_fields+="${accessor})," ;;
     *)    echo "Unknown format type: @${fmt}" >&2; exit 1 ;;
   esac

--- a/bin/kubectl-pnr
+++ b/bin/kubectl-pnr
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+NAMESPACE=""
+
+while getopts "n:" OPT; do
+    case "$OPT" in
+        n) NAMESPACE="$OPTARG" ;;
+        *)
+            echo "Usage: $0 -n <namespace>" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z $NAMESPACE ]]; then
+    echo "Error: namespace is required (-n <namespace>)" >&2
+    exit 1
+fi
+
+TMPDIR_REPORT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_REPORT"' EXIT
+
+PODS_FILE="$TMPDIR_REPORT/pods.json"
+NODES_FILE="$TMPDIR_REPORT/nodes.json"
+
+kubectl get pods -n "$NAMESPACE" -o json > "$PODS_FILE"
+
+# Extract unique node names from scheduled pods (skip unscheduled/Pending pods)
+NODE_NAMES=$(jq -r '[.items[].spec.nodeName // empty] | unique | .[]' "$PODS_FILE")
+
+echo '{"items":[]}' > "$NODES_FILE"
+if [[ -n $NODE_NAMES ]]; then
+    # shellcheck disable=SC2086
+    kubectl get nodes $NODE_NAMES -o json > "$NODES_FILE"
+fi
+
+jq -n --slurpfile pods "$PODS_FILE" --slurpfile nodes "$NODES_FILE" '
+  # Parse CPU string to millicores (integer)
+  def parse_cpu:
+    if . == null then null
+    elif test("m$") then (rtrimstr("m") | tonumber)
+    else (tonumber * 1000)
+    end;
+
+  # Parse memory string to bytes (integer)
+  def parse_memory:
+    if . == null then null
+    elif test("Ei$") then (rtrimstr("Ei") | tonumber * 1152921504606846976)
+    elif test("Pi$") then (rtrimstr("Pi") | tonumber * 1125899906842624)
+    elif test("Ti$") then (rtrimstr("Ti") | tonumber * 1099511627776)
+    elif test("Gi$") then (rtrimstr("Gi") | tonumber * 1073741824)
+    elif test("Mi$") then (rtrimstr("Mi") | tonumber * 1048576)
+    elif test("Ki$") then (rtrimstr("Ki") | tonumber * 1024)
+    elif test("E$")  then (rtrimstr("E")  | tonumber * 1000000000000000000)
+    elif test("P$")  then (rtrimstr("P")  | tonumber * 1000000000000000)
+    elif test("T$")  then (rtrimstr("T")  | tonumber * 1000000000000)
+    elif test("G$")  then (rtrimstr("G")  | tonumber * 1000000000)
+    elif test("M$")  then (rtrimstr("M")  | tonumber * 1000000)
+    elif test("k$")  then (rtrimstr("k")  | tonumber * 1000)
+    elif test("m$")  then (rtrimstr("m") | tonumber / 1000)
+    else (tonumber)
+    end;
+
+  # Format millicores back to human-readable
+  def format_cpu:
+    if . == null then null
+    elif . % 1000 == 0 then "\(. / 1000)"
+    else "\(.)m"
+    end;
+
+  # Format bytes back to largest clean unit
+  def format_memory:
+    if . == null then null
+    elif . % 1073741824 == 0 then "\(. / 1073741824)Gi"
+    elif . % 1048576 == 0 then "\(. / 1048576)Mi"
+    elif . % 1024 == 0 then "\(. / 1024)Ki"
+    else "\(.)"
+    end;
+
+  # Sum a resource field across containers.
+  # Returns null if ALL containers lack the field; otherwise sums set values (unset = 0).
+  def sum_field(path_expr):
+    [.[] | path_expr] |
+    if all(. == null) then null
+    else map(. // 0) | add
+    end;
+
+  # Build node lookup: node_name -> {instance_type, cpu_capacity, memory_capacity}
+  ($nodes[0].items | map({
+    key: .metadata.name,
+    value: {
+      instance_type: (.metadata.labels["node.kubernetes.io/instance-type"] // .metadata.labels["beta.kubernetes.io/instance-type"]),
+      cpu_capacity: .status.capacity.cpu,
+      memory_capacity: .status.capacity.memory
+    }
+  }) | from_entries) as $node_map |
+
+  # Process each pod
+  [
+    $pods[0].items[] |
+    .metadata as $meta |
+    .spec as $spec |
+
+    # Only regular containers (not init containers)
+    ($spec.containers | map(.resources // {})) as $resources |
+
+    # Sum resource fields
+    ($resources | sum_field(.requests.cpu | parse_cpu)) as $cpu_req |
+    ($resources | sum_field(.limits.cpu | parse_cpu)) as $cpu_lim |
+    ($resources | sum_field(.requests.memory | parse_memory)) as $mem_req |
+    ($resources | sum_field(.limits.memory | parse_memory)) as $mem_lim |
+
+    # Node info (null for unscheduled pods)
+    ($spec.nodeName // null) as $node_name |
+    (if $node_name then $node_map[$node_name] else null end) as $node_info |
+
+    {
+      namespace: $meta.namespace,
+      name: $meta.name,
+      cpu_request: ($cpu_req | format_cpu),
+      cpu_limit: ($cpu_lim | format_cpu),
+      memory_request: ($mem_req | format_memory),
+      memory_limit: ($mem_lim | format_memory),
+      node_name: $node_name,
+      node_instance_type: (if $node_info then $node_info.instance_type else null end),
+      node_cpu_capacity: (if $node_info then $node_info.cpu_capacity else null end),
+      node_memory_capacity: (if $node_info then $node_info.memory_capacity else null end)
+    }
+  ] | sort_by(.name) | {items: .}
+'

--- a/bin/kubectl-pnr
+++ b/bin/kubectl-pnr
@@ -5,8 +5,8 @@ set -eou pipefail
 NAMESPACE=""
 
 while getopts "n:" OPT; do
-    case "$OPT" in
-        n) NAMESPACE="$OPTARG" ;;
+    case "${OPT}" in
+        n) NAMESPACE="${OPTARG}" ;;
         *)
             echo "Usage: $0 -n <namespace>" >&2
             exit 1
@@ -14,7 +14,7 @@ while getopts "n:" OPT; do
     esac
 done
 
-if [[ -z $NAMESPACE ]]; then
+if [[ -z ${NAMESPACE} ]]; then
     echo "Error: namespace is required (-n <namespace>)" >&2
     exit 1
 fi
@@ -22,21 +22,21 @@ fi
 TMPDIR_REPORT=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_REPORT"' EXIT
 
-PODS_FILE="$TMPDIR_REPORT/pods.json"
-NODES_FILE="$TMPDIR_REPORT/nodes.json"
+PODS_FILE="${TMPDIR_REPORT}/pods.json"
+NODES_FILE="${TMPDIR_REPORT}/nodes.json"
 
-kubectl get pods -n "$NAMESPACE" -o json > "$PODS_FILE"
+kubectl get pods -n "${NAMESPACE}" -o json > "${PODS_FILE}"
 
 # Extract unique node names from scheduled pods (skip unscheduled/Pending pods)
-NODE_NAMES=$(jq -r '[.items[].spec.nodeName // empty] | unique | .[]' "$PODS_FILE")
+NODE_NAMES=$(jq -r '[.items[].spec.nodeName // empty] | unique | .[]' "${PODS_FILE}")
 
-echo '{"items":[]}' > "$NODES_FILE"
-if [[ -n $NODE_NAMES ]]; then
+echo '{"items":[]}' > "${NODES_FILE}"
+if [[ -n ${NODE_NAMES} ]]; then
     # shellcheck disable=SC2086
-    kubectl get nodes $NODE_NAMES -o json > "$NODES_FILE"
+    kubectl get nodes ${NODE_NAMES} -o json > "${NODES_FILE}"
 fi
 
-jq -n --slurpfile pods "$PODS_FILE" --slurpfile nodes "$NODES_FILE" '
+jq -n --slurpfile pods "${PODS_FILE}" --slurpfile nodes "${NODES_FILE}" '
   # Parse CPU string to millicores (integer)
   def parse_cpu:
     if . == null then null

--- a/gitconfig
+++ b/gitconfig
@@ -171,6 +171,8 @@
     tme = !git lme --no-merges --stat --name-only --pretty=format:'' | sort -u
                                 ; touchlist: files I have modified
     ur = update-ref             ; update sym ref safely
+    w = worktree list
+    wa = worktree add
     wc = whatchanged            ; what files changed
     wcme = !git whatchanged --author=$(git config user.email) || exit 0
                                 ;   by me, and always succeed

--- a/zsh-custom/k8s.zsh
+++ b/zsh-custom/k8s.zsh
@@ -28,7 +28,7 @@ function kcstat() {
   for n in $(kubectl get node | tail -n +2 | awk '{ print $1 }')
   do
     echo $n
-    echo -e "$(kubectl describe node $node | grep -A 4 'Allocated resources')\n"
+    echo -e "$(kubectl describe node $n | grep -A 4 'Allocated resources')\n"
   done
 }
 

--- a/zsh-custom/plugins/kube/kube.plugin.zsh
+++ b/zsh-custom/plugins/kube/kube.plugin.zsh
@@ -2,8 +2,10 @@ typeset -a KUBE_CONFIG_DIRS=( ~/.kube/configs ~/.ssh/kubeconfigs )
 
 function kt {
   local file=$1
+  local dir cand
   if [[ -z "$file" ]]
   then
+    local active="${KUBECONFIG%%:*}"
     for dir in "${KUBE_CONFIG_DIRS[@]}"
     do
       if [[ ! -d "$dir" ]]
@@ -12,7 +14,7 @@ function kt {
       fi
       for cand in "$dir"/*(N:t)
       do
-        if [[ -n "$KUBECONFIG" && "$KUBECONFIG" = "$dir/$cand" ]]
+        if [[ -n "$active" && "$active" = "$dir/$cand" ]]
         then
           echo "* $cand"
         else
@@ -53,7 +55,7 @@ function kubectl {
     then
       i=$((i + 1))
       continue
-    elif [[ ${args[$i]} == --namespace=* ]]
+    elif [[ ${args[$i]} == -n=* ]] || [[ ${args[$i]} == --namespace=* ]]
     then
       continue
     else
@@ -65,6 +67,11 @@ function kubectl {
 
   #echo "cmd: $cmd"
   #echo "rest: ${(qq)args[@]}"
+  if [[ -z "$cmd" ]]; then
+    command kubectl "$@"
+    return
+  fi
+
   if type "__kubectl_${cmd}" >/dev/null 2>&1
   then
     "__kubectl_${cmd}" "${args[@]}"
@@ -114,6 +121,15 @@ function __kubectl_get {
       continue
     fi
 
+    if [[ ${args[$i]} == -n=* ]] || [[ ${args[$i]} == --namespace=* ]]
+    then
+      local _nval="${args[$i]#*=}"
+      args=( "${args[@]:0:$((i-1))}" "-n" "$_nval" "${args[@]:$i}" )
+      namespace_idx=$((i + 1))
+      i=$((i + 2))
+      continue
+    fi
+
     if [[ ${args[$i]} == -o ]] || [[ ${args[$i]} == --output ]]
     then
       output_idx=$((i + 1))
@@ -125,7 +141,7 @@ function __kubectl_get {
       local _oval="${args[$i]#*=}"
       args=( "${args[@]:0:$((i-1))}" "-o" "$_oval" "${args[@]:$i}" )
       output_idx=$((i + 1))
-      i=$((i + 1))
+      i=$((i + 2))
       continue
     fi
 
@@ -181,7 +197,7 @@ function __kubectl_get {
     then
       namespace=${namespace//\//--}
       namespace=${namespace//_/-}
-      echo "kt: rewriting namespace '${args[$namespace_idx]}' -> '${namespace}'" >&2
+      echo "kubectl get: rewriting namespace '${args[$namespace_idx]}' -> '${namespace}'" >&2
       args[$namespace_idx]=$namespace
     fi
   fi

--- a/zsh-custom/plugins/kube/kube.plugin.zsh
+++ b/zsh-custom/plugins/kube/kube.plugin.zsh
@@ -97,7 +97,9 @@ function prompt_kube_plugin() {
 #    and sets the output format to it if it exists.
 # 3. "kc get foo -o .bar" replaces the output format with "-o json" and pipes
 #    to jq automatically, passing ".bar".
-# 4. "kc get foo" sets a default --sort-by unless one was provided.
+# 4. "kc get foo -o @bar" looks for the formatter spec "bar.kf" and pipes
+#    JSON through kubectl-formatter with the field specs from the file.
+# 5. "kc get foo" sets a default --sort-by unless one was provided.
 function __kubectl_get {
   local -a args
   local i
@@ -176,6 +178,23 @@ function __kubectl_get {
       fi
 
       args[$output_idx]="custom-columns-file=${tplfile}"
+    elif [[ ${args[$output_idx]} == @* ]]
+    then
+      local kffile="${DOTFILES}/zsh-custom/plugins/kube/templates/${args[$output_idx]#@}.kf"
+      if [[ ! -f ${kffile} ]]
+      then
+        echo "Error: formatter spec file not found ${kffile}" >&2
+        return 1
+      fi
+
+      local -a kf_specs=()
+      while IFS= read -r line; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        kf_specs+=( "$line" )
+      done < "$kffile"
+
+      pipe_cmd=( "kubectl-formatter" "${kf_specs[@]}" )
+      args[$output_idx]="json"
     elif [[ ${args[$output_idx]} == .* ]]
     then
       pipe_cmd=( "jq" "-r" "${args[$output_idx]}" )

--- a/zsh-custom/plugins/kube/kube.plugin.zsh
+++ b/zsh-custom/plugins/kube/kube.plugin.zsh
@@ -41,6 +41,8 @@ function kt {
 
 function kubectl {
   local cmd
+  local -a args
+  local i
 
   args=( "$@" )
   for ((i = 1; i <= $#args; i++))
@@ -54,12 +56,10 @@ function kubectl {
       continue
     else
       cmd="${args[$i]}"
-      #echo "$i: ${args[@]}" >&2
-      args[$i]=()
+      args=( "${args[@]:0:$((i-1))}" "${args[@]:$i}" )
       break
     fi
   done
-  #args=( "${args[@]}" )
 
   #echo "cmd: $cmd"
   #echo "rest: ${(qq)args[@]}"
@@ -90,6 +90,10 @@ function prompt_kube_plugin() {
 #    to jq automatically, passing ".bar".
 # 4. "kc get foo" sets a default --sort-by unless one was provided.
 function __kubectl_get {
+  local -a args
+  local i
+  local tplfile
+
   args=( "$@" )
 
   local rsrc
@@ -100,7 +104,7 @@ function __kubectl_get {
   local output_idx=-1
   local pipe_cmd=()
 
-  for ((i = 0; i <= $#args; i++))
+  for ((i = 1; i <= $#args; i++))
   do
     if [[ ${args[$i]} == -n ]] || [[ ${args[$i]} == --namespace ]]
     then

--- a/zsh-custom/plugins/kube/kube.plugin.zsh
+++ b/zsh-custom/plugins/kube/kube.plugin.zsh
@@ -1,14 +1,16 @@
+typeset -a KUBE_CONFIG_DIRS=( ~/.kube/configs ~/.ssh/kubeconfigs )
+
 function kt {
   local file=$1
   if [[ -z "$file" ]]
   then
-    for dir in ~/.kube/configs ~/.ssh/kubeconfigs
+    for dir in "${KUBE_CONFIG_DIRS[@]}"
     do
       if [[ ! -d "$dir" ]]
       then
         continue
       fi
-      for cand in $(ls "$dir")
+      for cand in "$dir"/*(N:t)
       do
         if [[ -n "$KUBECONFIG" && "$KUBECONFIG" = "$dir/$cand" ]]
         then
@@ -27,7 +29,7 @@ function kt {
     return
   fi
 
-  for dir in ~/.kube/configs ~/.ssh/kubeconfigs
+  for dir in "${KUBE_CONFIG_DIRS[@]}"
   do
     if [[ -f "$dir/$file" ]]
     then
@@ -75,8 +77,8 @@ function kubectl {
 function prompt_kube_plugin() {
   local name cfg
   [[ -n "$KUBECONFIG" ]] || return
-  cfg="$(echo "$KUBECONFIG" | awk -F: '{print $1}')"
-  name="$(basename $cfg)"
+  cfg="${KUBECONFIG%%:*}"
+  name="${cfg:t}"
   p10k segment -s NORMAL -r -i KUBERNETES_ICON -b black -f white -t "$name"
 }
 
@@ -115,6 +117,15 @@ function __kubectl_get {
     if [[ ${args[$i]} == -o ]] || [[ ${args[$i]} == --output ]]
     then
       output_idx=$((i + 1))
+      continue
+    fi
+
+    if [[ ${args[$i]} == -o=* ]] || [[ ${args[$i]} == --output=* ]]
+    then
+      local _oval="${args[$i]#*=}"
+      args=( "${args[@]:0:$((i-1))}" "-o" "$_oval" "${args[@]:$i}" )
+      output_idx=$((i + 1))
+      i=$((i + 1))
       continue
     fi
 
@@ -170,6 +181,7 @@ function __kubectl_get {
     then
       namespace=${namespace//\//--}
       namespace=${namespace//_/-}
+      echo "kt: rewriting namespace '${args[$namespace_idx]}' -> '${namespace}'" >&2
       args[$namespace_idx]=$namespace
     fi
   fi
@@ -202,3 +214,16 @@ function __kubectl_get {
     command kubectl get "${args[@]}" | "${pipe_cmd[@]}"
   fi
 }
+
+
+function _kt {
+  local -a configs
+  local dir
+  for dir in "${KUBE_CONFIG_DIRS[@]}"
+  do
+    [[ -d "$dir" ]] || continue
+    configs+=( "$dir"/*(N:t) )
+  done
+  _describe 'kubeconfig' configs
+}
+compdef _kt kt

--- a/zsh-custom/plugins/kube/templates/pods.kf
+++ b/zsh-custom/plugins/kube/templates/pods.kf
@@ -1,0 +1,5 @@
+# pods.kf
+namespace
+NAME:metadata.name
+AGE:metadata.creationTimestamp@ts
+cpu_request@qty


### PR DESCRIPTION
  - kubectl-formatter: a script that formats JSON with a top-level items array into kubectl-style tables using custom column specs with support for quantity (`@qty`), memory (`@mem`), and relative timestamp (`@ts`) formatting
  - kubectl-pnr: a pod-to-node resource report that shows per-pod CPU/memory requests and limits alongside node capacity info
  - Fix bugs in the kubectl `kc` wrapper
